### PR TITLE
Add state example

### DIFF
--- a/examples/get-and-set-state-json.ts
+++ b/examples/get-and-set-state-json.ts
@@ -1,0 +1,190 @@
+import * as dotenv from "dotenv";
+dotenv.config();
+
+import { TeamLeader } from "../src/teamMembers";
+import { Team } from "../src/team";
+
+async function run() {
+  const assistant = new TeamLeader(
+    "State Manager",
+    `Given a UUID, you can create, read, update, and delete blobs associated with that UUID in the global state.
+When creating or updating blobs, you must provide a JSON-serializable object.`,
+    {
+      enabled: false,
+      workingDirectory: "",
+    },
+    {
+      read_json_blob: {
+        schema: {
+          name: "read_json_blob",
+          description: "Retrieve JSON blob associated with a UUID",
+          parameters: {
+            type: "object",
+            required: ["uuid"],
+            properties: {
+              uuid: {
+                type: "string",
+              },
+            },
+          },
+        },
+        function: async function read_json_blob(args: { uuid: string }) {
+          const stateFile = `${__dirname}/state.json`;
+          const fs = require("fs");
+          if (!fs.existsSync(stateFile)) {
+            fs.writeFileSync(stateFile, "{}");
+          }
+          const state = JSON.parse(fs.readFileSync(stateFile, "utf8"));
+          if (state[args.uuid]) {
+            return JSON.stringify(state[args.uuid]);
+          }
+          return "No JSON blob found.";
+        },
+      },
+      create_new_json_blob_for_uuid: {
+        schema: {
+          name: "create_new_json_blob_for_uuid",
+          description:
+            "Insert JSON blob into the global state and associate it with a UUID.",
+          parameters: {
+            type: "object",
+            required: ["json_blob", "uuid"],
+            properties: {
+              json_blob: {
+                type: "object",
+                description: "JSON blob to store.",
+              },
+              uuid: {
+                type: "string",
+              },
+            },
+          },
+        },
+        function: async function create_new_json_blob_for_uuid(args: {
+          uuid: string;
+          json_blob: any;
+        }) {
+          if (!args.json_blob) {
+            return "No json_blob provided.";
+          }
+
+          const stateFile = `${__dirname}/state.json`;
+          const fs = require("fs");
+          if (!fs.existsSync(stateFile)) {
+            fs.writeFileSync(stateFile, "{}");
+          }
+
+          const state = JSON.parse(fs.readFileSync(stateFile, "utf8"));
+          const existingBlob = state[args.uuid] || {};
+
+          Object.keys(args.json_blob).forEach((key) => {
+            existingBlob[key] = args.json_blob[key];
+          });
+
+          state[args.uuid] = existingBlob;
+          fs.writeFileSync(stateFile, JSON.stringify(state, null, 2));
+          return `Created JSON blob for ${args.uuid}`;
+        },
+      },
+      update_existing_json_blob: {
+        schema: {
+          name: "update_existing_json_blob",
+          description: "Update JSON blob associated with a UUID.",
+          parameters: {
+            type: "object",
+            required: ["json_blob", "uuid"],
+            properties: {
+              json_blob: {
+                type: "object",
+                description: "JSON blob to update the existing blob with.",
+              },
+              uuid: {
+                type: "string",
+              },
+            },
+          },
+        },
+        function: async function update_existing_json_blob(args: {
+          uuid: string;
+          json_blob: any;
+        }) {
+          if (!args.json_blob) {
+            return "No json_blob provided.";
+          }
+
+          const stateFile = `${__dirname}/state.json`;
+          const fs = require("fs");
+          if (!fs.existsSync(stateFile)) {
+            fs.writeFileSync(stateFile, "{}");
+          }
+
+          const state = JSON.parse(fs.readFileSync(stateFile, "utf8"));
+          const existingBlob = state[args.uuid] || {};
+
+          Object.keys(args.json_blob).forEach((key) => {
+            existingBlob[key] = args.json_blob[key];
+          });
+
+          state[args.uuid] = existingBlob;
+          fs.writeFileSync(stateFile, JSON.stringify(state, null, 2));
+          return `Updated JSON blob for ${args.uuid}`;
+        },
+      },
+      delete_json_blob: {
+        schema: {
+          name: "delete_json_blob",
+          description: "Delete the JSON blob associated with a UUID.",
+          parameters: {
+            type: "object",
+            required: ["uuid"],
+            properties: {
+              uuid: {
+                type: "string",
+              },
+            },
+          },
+        },
+        function: async function delete_json_blob(args: { uuid: string }) {
+          const stateFile = `${__dirname}/state.json`;
+          const fs = require("fs");
+          if (!fs.existsSync(stateFile)) {
+            fs.writeFileSync(stateFile, "{}");
+          }
+          const state = JSON.parse(fs.readFileSync(stateFile, "utf8"));
+          if (state[args.uuid]) {
+            delete state[args.uuid];
+            fs.writeFileSync(stateFile, JSON.stringify(state, null, 2));
+            return `Deleted blob for ${args.uuid}`;
+          }
+          return "No blob found.";
+        },
+      },
+    }
+  );
+
+  async function handleTeamStateUpdate(teamState: any) {
+    // console.log(JSON.stringify(teamState, null, 2));
+  }
+
+  const team = new Team(assistant, [], handleTeamStateUpdate);
+
+  const teamState = team.getState();
+  const restoredTeam = Team.fromState(teamState);
+
+  // const chat = await restoredTeam.chat(
+  //   "Could you store the email address contact@example.com at UUID bbaa7261-ea1c-427c-b5b5-48b284b3ab48?"
+  // );
+  // const chat = await restoredTeam.chat(
+  //   "Could you store the name John Doe at UUID bbaa7261-ea1c-427c-b5b5-48b284b3ab48?"
+  //   );
+  // const chat = await restoredTeam.chat(
+  //   "Please fetch the data for UUID bbaa7261-ea1c-427c-b5b5-48b284b3ab48"
+  // );
+  const chat = await restoredTeam.chat(
+    "Please delete the data for UUID bbaa7261-ea1c-427c-b5b5-48b284b3ab48"
+  );
+
+  console.log(chat);
+}
+
+run();

--- a/src/team.ts
+++ b/src/team.ts
@@ -186,6 +186,8 @@ export class Team {
 
     const teamMember = this.members.find((member) => member.name === name);
     if (!teamMember) {
+      // TODO: handle more gracefully? sometimes the team member is just 'user'
+      //       so we could special case handle it if it appears more frequently
       throw new Error(`Team member with name ${name} not found.`);
     }
     return teamMember;

--- a/src/teamMembers.ts
+++ b/src/teamMembers.ts
@@ -98,12 +98,23 @@ ${this.originalSystemPrompt}`;
       );
     };
 
-    // Handle the case in which a function call appears in body of completion
+    // Handle the case in which a control function call appears in body of completion
     if (typeof completion === "string" && canPassControl) {
       const controlFunctions = [GIVE_BACK_CONTROL, GIVE_CONTROL, PASS_TO_USER];
       for (const controlFunction of controlFunctions) {
         if (completion.includes(controlFunction)) {
           completion = await retryCompletion(controlFunction);
+          break;
+        }
+      }
+    }
+
+    // Handle the case in which a regular function call appears in body of completion
+    if (typeof completion === "string") {
+      const functionNames = Object.keys(functionConfig);
+      for (const functionName of functionNames) {
+        if (completion.includes(functionName)) {
+          completion = await retryCompletion(functionName);
           break;
         }
       }


### PR DESCRIPTION
I'm not sure why - possible the wording I've used ('blob', 'state', 'JSON blob', etc.) is throwing GPT4 off - but the function calls for creating and updating state don't seem include the JSON blob initially, but then it corrects itself and makes the correct function call, e.g.
```
[
  {
    sender: 'Human Admin User',
    content: 'Could you store the name John Doe at UUID bbaa7261-ea1c-427c-b5b5-48b284b3ab48?'
  },
  {
    sender: 'Executor',
    content: 'function call: create_new_json_blob_for_uuid\n' +
      'arguments: {\n' +
      '  "uuid": "bbaa7261-ea1c-427c-b5b5-48b284b3ab48"\n' +
      '}\n' +
      'result: No json_blob provided.'
  },
  {
    sender: 'Executor',
    content: "Apologies for the confusion, it seems I didn't provide the necessary data. Let's try that again.\n" +
      'function call: create_new_json_blob_for_uuid\n' +
      'arguments: {\n' +
      '  "uuid": "bbaa7261-ea1c-427c-b5b5-48b284b3ab48",\n' +
      '  "json_blob": {\n' +
      '    "name": "John Doe"\n' +
      '  }\n' +
      '}\n' +
      'result: Created JSON blob for bbaa7261-ea1c-427c-b5b5-48b284b3ab48'
  }
]
```